### PR TITLE
Improve RSI calculator error handling

### DIFF
--- a/src/services/indicators/rsi_calculator.py
+++ b/src/services/indicators/rsi_calculator.py
@@ -166,6 +166,24 @@ class RSICalculator(LoggerMixin):
             # Рассчитываем RSI
             return self.calculate_standard_rsi(close_prices, period)
 
+        except InsufficientDataError as e:
+            self.logger.warning(
+                "Insufficient candle data for RSI",
+                pair_id=pair_id,
+                timeframe=timeframe,
+                required=e.details.get("required"),
+                provided=e.details.get("provided")
+            )
+            return None
+        except InvalidIndicatorParameterError as e:
+            self.logger.error(
+                "Invalid RSI parameter",
+                pair_id=pair_id,
+                timeframe=timeframe,
+                parameter=e.details.get("parameter"),
+                value=e.details.get("value"),
+            )
+            return None
         except Exception as e:
             self.logger.error(
                 "Error calculating RSI from candles",


### PR DESCRIPTION
## Summary
- add specific exception handling in `calculate_rsi_from_candles`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: websockets)*

------
https://chatgpt.com/codex/tasks/task_e_688a858b4fe4832ba74a99f47fce110f