### PR TITLE
Increase candle volume precision

### DIFF
--- a/src/data/models/candle_model.py
+++ b/src/data/models/candle_model.py
@@ -87,13 +87,13 @@ class Candle(Base):
 
     # Объем торгов
     volume: Mapped[Decimal] = mapped_column(
-        Numeric(18, 8),
+        Numeric(24, 8),
         nullable=False,
         comment="Объем торгов в базовой валюте"
     )
 
     quote_volume: Mapped[Optional[Decimal]] = mapped_column(
-        Numeric(18, 8),
+        Numeric(24, 8),
         nullable=True,
         comment="Объем торгов в котируемой валюте"
     )


### PR DESCRIPTION
## Summary
- adjust volume fields to handle larger amounts in `Candle` model

## Testing
- `pytest -q` *(fails: fixture 'self' not found in test_stream_manager)*

------
https://chatgpt.com/codex/tasks/task_e_688a91fc23ec832bb362702601ce37ca