### PR TITLE
Validate numeric candle volumes

### DIFF
--- a/src/services/data_fetchers/historical/historical_data_processor.py
+++ b/src/services/data_fetchers/historical/historical_data_processor.py
@@ -10,7 +10,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
 
 from data.models.candle_model import Candle
-from utils.validators import validate_binance_kline_data, validate_binance_kline_data_detailed
+from utils.validators import (
+    validate_binance_kline_data,
+    validate_binance_kline_data_detailed,
+    validate_numeric_field,
+)
 from utils.logger import LoggerMixin
 
 # Настройка логирования
@@ -151,6 +155,9 @@ class HistoricalDataProcessor(LoggerMixin):
         # ]
 
         try:
+            validated_volume = validate_numeric_field(kline[5], "volume")
+            validated_quote_volume = validate_numeric_field(kline[7], "quote_volume")
+
             return {
                 "t": int(kline[0]),  # open_time
                 "T": int(kline[6]),  # close_time
@@ -160,8 +167,8 @@ class HistoricalDataProcessor(LoggerMixin):
                 "h": str(kline[2]),  # high_price
                 "l": str(kline[3]),  # low_price
                 "c": str(kline[4]),  # close_price
-                "v": str(kline[5]),  # volume
-                "q": str(kline[7]),  # quote_asset_volume
+                "v": str(validated_volume),  # volume
+                "q": str(validated_quote_volume),  # quote_asset_volume
                 "n": int(kline[8]),  # number_of_trades
                 "V": str(kline[9]),  # taker_buy_base_asset_volume
                 "Q": str(kline[10]),  # taker_buy_quote_asset_volume

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -254,6 +254,39 @@ def validate_volume(volume: Union[str, float, Decimal]) -> tuple[bool, Optional[
         return False, "Неверный формат объема"
 
 
+def validate_numeric_field(value: Union[str, float, Decimal], field_name: str) -> Decimal:
+    """Валидировать числовое значение и вернуть Decimal.
+
+    Args:
+        value: Значение для проверки.
+        field_name: Название поля для сообщений об ошибке.
+
+    Returns:
+        Decimal: Валидированное значение.
+
+    Raises:
+        ValueError: Если значение некорректно.
+    """
+    try:
+        if isinstance(value, str):
+            value = value.strip()
+        decimal_value = Decimal(str(value))
+
+        if decimal_value.is_nan() or decimal_value.is_infinite():
+            raise ValueError
+
+        if decimal_value < 0:
+            raise ValueError
+
+        if decimal_value > Decimal("1e50"):
+            raise ValueError
+
+        return decimal_value
+
+    except (InvalidOperation, ValueError, TypeError):
+        raise ValueError(f"Invalid numeric value for {field_name}")
+
+
 def validate_user_id(user_id: Union[str, int]) -> tuple[bool, Optional[str]]:
     """
     Валидировать ID пользователя Telegram.


### PR DESCRIPTION
## Summary
- validate numerical fields in validators
- parse and validate candle volumes before saving

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'websockets')*

------
https://chatgpt.com/codex/tasks/task_e_688a96d8867c832b960ec82b9984d708