### PR TITLE
Add Telegram error and time utility imports

### DIFF
--- a/src/bot/handlers/my_pairs/my_pairs_handler.py
+++ b/src/bot/handlers/my_pairs/my_pairs_handler.py
@@ -9,8 +9,11 @@ from aiogram import Router, F
 from aiogram.types import CallbackQuery, InlineKeyboardButton
 from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
+from aiogram.exceptions import TelegramBadRequest
 from sqlalchemy.ext.asyncio import AsyncSession
 import structlog
+import re
+from datetime import datetime
 
 from data.models.user_pair_model import UserPair
 from utils.logger import log_user_action


### PR DESCRIPTION
## Summary
- add imports for TelegramBadRequest, regular expressions, and datetime in my_pairs handler

## Testing
- `pytest -q` *(fails: fixture 'self' not found in scripts/test_websocket.py)*

------
https://chatgpt.com/codex/tasks/task_e_688aa1c5c054832bb0423da101cc6370