### PR TITLE
feat: add RSI debug handler

### DIFF
--- a/src/bot/handlers/debug_rsi_handler.py
+++ b/src/bot/handlers/debug_rsi_handler.py
@@ -1,0 +1,103 @@
+"""
+Путь: src/bot/handlers/debug_rsi_handler.py
+Описание: Обработчик команд отладки RSI
+Автор: Crypto Bot Team
+Дата создания: 2025-07-30
+"""
+
+from aiogram import Router, F
+from aiogram.types import Message
+from aiogram.filters import Command
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from utils.rsi_debug import debug_rsi_calculation
+from services.indicators.rsi_calculator import RSICalculator
+from data.models.candle_model import Candle
+from utils.logger import get_logger
+
+debug_router = Router()
+logger = get_logger(__name__)
+
+@debug_router.message(Command("debug_rsi"))
+async def handle_debug_rsi(message: Message, session: AsyncSession):
+    """
+    Отладочная команда для проверки расчета RSI.
+    Формат: /debug_rsi BTCUSDT 1h
+    """
+    user_id = message.from_user.id
+    
+    # Только для админов (замените на ваш ID)
+    if user_id != 198024201:  # Ваш Telegram ID
+        await message.reply("❌ Команда доступна только администратору")
+        return
+    
+    try:
+        # Парсим аргументы
+        args = message.text.split()
+        if len(args) != 3:
+            await message.reply("Формат: /debug_rsi BTCUSDT 1h")
+            return
+            
+        symbol = args[1].upper()
+        timeframe = args[2]
+        
+        # Получаем пару
+        from data.models.pair_model import Pair
+        pair = await Pair.get_by_symbol(session, symbol)
+        if not pair:
+            await message.reply(f"❌ Пара {symbol} не найдена")
+            return
+        
+        # Получаем последние 50 свечей
+        candles = await Candle.get_latest_candles(
+            session=session,
+            pair_id=pair.id,
+            timeframe=timeframe,
+            limit=50
+        )
+        
+        if len(candles) < 15:
+            await message.reply(f"❌ Недостаточно данных: {len(candles)} свечей")
+            return
+        
+        # Извлекаем цены
+        prices = [float(candle.close_price) for candle in candles]
+        
+        # Отладка расчета
+        debug_info = debug_rsi_calculation(prices, 14)
+        
+        # Рассчитываем RSI нашим калькулятором
+        rsi_calc = RSICalculator()
+        rsi_result = rsi_calc.calculate_standard_rsi(prices, 14)
+        
+        # Формируем ответ
+        response = f"""🔍 <b>Отладка RSI для {symbol} ({timeframe})</b>
+
+<b>Данные:</b>
+- Свечей загружено: {len(candles)}
+- Цены для расчета: {len(prices)}
+
+<b>Последние 5 цен:</b>
+{' → '.join([str(round(p, 2)) for p in prices[-5:]])}
+
+<b>Расчет:</b>
+- Средняя прибыль: {debug_info.get('avg_gain', 'N/A')}
+- Средний убыток: {debug_info.get('avg_loss', 'N/A')}
+- RS: {debug_info.get('rs', 'N/A')}
+
+<b>Результат:</b>
+- Наш RSI: {rsi_result.value if rsi_result else 'Ошибка расчета'}
+- Отладочный RSI: {debug_info.get('rsi', 'N/A')}
+
+<i>Сравните с TradingView для проверки точности</i>"""
+
+        await message.reply(response)
+        
+    except Exception as e:
+        logger.error("Error in debug RSI", error=str(e), user_id=user_id)
+        await message.reply(f"❌ Ошибка: {str(e)}")
+
+
+def register_debug_handlers(dp):
+    """Зарегистрировать обработчики отладки"""
+    dp.include_router(debug_router)

--- a/src/main.py
+++ b/src/main.py
@@ -37,6 +37,7 @@ from utils.exceptions import ConfigurationError, DatabaseError
 from bot.handlers.add_pair import register_add_pair_handlers
 from bot.handlers.remove_pair_handler import register_remove_pair_handlers
 from bot.handlers.my_pairs import register_my_pairs_handlers
+from bot.handlers.debug_rsi_handler import register_debug_handlers
 
 # Импорты для системы сигналов и уведомлений
 from services.websocket.stream_manager import StreamManager
@@ -91,6 +92,7 @@ async def setup_dispatcher() -> Dispatcher:
     register_add_pair_handlers(dp)
     register_remove_pair_handlers(dp)
     register_my_pairs_handlers(dp)
+    register_debug_handlers(dp)
 
     logger.info("Dispatcher configured and handlers registered")
     return dp


### PR DESCRIPTION
## Summary
- add `/debug_rsi` admin-only handler to inspect RSI calculations on demand
- wire debug handler into dispatcher setup

## Testing
- `pip install websockets python-binance`
- `pip install structlog`
- `pip install pydantic==2.6.2 pydantic-settings==2.2.1`
- `pytest -q` *(fails: fixture 'self' not found in test_stream_manager)*

------
https://chatgpt.com/codex/tasks/task_e_688aa7335e90832b89667a2df62c8b8d