### PR TITLE
feat: process kline data with indicator updates

### DIFF
--- a/src/services/websocket/binance_data_processor.py
+++ b/src/services/websocket/binance_data_processor.py
@@ -5,37 +5,28 @@
 Дата создания: 2025-07-29
 """
 
-import asyncio
-from typing import Dict, Any, Optional
-from datetime import datetime
+from decimal import Decimal
+from typing import Any, Dict
 
-from data.database import get_session
+from sqlalchemy import update
+
+from data.database import get_session as get_async_session
 from services.signals.signal_aggregator import signal_aggregator
 from services.cache.candle_cache import candle_cache
 from utils.logger import get_logger
-from utils.exceptions import BinanceDataError, SignalError
 
 
 class BinanceDataProcessor:
-    """
-    Обработчик данных от Binance WebSocket.
+    """Обработчик данных от Binance WebSocket."""
 
-    Принимает сообщения от WebSocket и передает их в систему сигналов.
-    """
-
-    def __init__(self):
+    def __init__(self) -> None:
         """Инициализация обработчика."""
         self.logger = get_logger(__name__)
         self.processed_messages = 0
         self.processing_errors = 0
 
     async def process_websocket_message(self, message: Dict[str, Any]) -> None:
-        """
-        Обработать сообщение от WebSocket.
-
-        Args:
-            message: Сообщение от Binance WebSocket
-        """
+        """Обработать сообщение от WebSocket."""
         try:
             stream_name = message.get("stream", "")
             data = message.get("data", {})
@@ -44,9 +35,8 @@ class BinanceDataProcessor:
                 self.logger.warning("Invalid message format", message=message)
                 return
 
-            # Определяем тип потока
             if "@kline_" in stream_name:
-                await self._process_kline_message(stream_name, data)
+                await self.process_kline_data(data)
             elif "@ticker" in stream_name:
                 await self._process_ticker_message(stream_name, data)
             else:
@@ -54,141 +44,194 @@ class BinanceDataProcessor:
 
             self.processed_messages += 1
 
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - защищает от неожиданных ошибок
             self.processing_errors += 1
             self.logger.error(
                 "Error processing WebSocket message",
                 error=str(e),
-                message=message
+                message=message,
             )
 
-    async def _process_kline_message(self, stream_name: str, data: Dict[str, Any]) -> None:
-        """
-        Обработать kline сообщение.
-
-        Args:
-            stream_name: Название потока
-            data: Данные kline
-        """
+    async def process_kline_data(self, data: Dict[str, Any]) -> None:
+        """Обработать данные kline с сохранением в БД и пересчетом индикаторов."""
         try:
-            kline_data = data.get("k", {})
+            kline = data.get("k", {})
+            symbol = kline.get("s", "").upper()
+            timeframe = kline.get("i", "")
+            is_closed = kline.get("x", False)
 
-            if not kline_data:
-                self.logger.warning("Empty kline data", stream=stream_name)
+            if not is_closed:
                 return
 
-            # Извлекаем информацию
-            symbol = kline_data.get("s")  # BTCUSDT
-            timeframe = kline_data.get("i")  # 1h
-            is_closed = kline_data.get("x", False)  # Закрыта ли свеча
+            self.logger.debug(f"Processing closed kline: {symbol} {timeframe}")
 
-            if not symbol or not timeframe:
-                self.logger.warning(
-                    "Missing symbol or timeframe",
+            async with get_async_session() as session:
+                from data.models.pair_model import Pair
+                from data.models.candle_model import Candle
+
+                pair = await Pair.get_by_symbol(session, symbol)
+
+                if not pair:
+                    self.logger.warning(f"Pair {symbol} not found in database")
+                    return
+
+                candle = Candle(
+                    pair_id=pair.id,
+                    timeframe=timeframe,
+                    open_time=int(kline.get("t", 0)),
+                    close_time=int(kline.get("T", 0)),
+                    open_price=Decimal(kline.get("o", "0")),
+                    high_price=Decimal(kline.get("h", "0")),
+                    low_price=Decimal(kline.get("l", "0")),
+                    close_price=Decimal(kline.get("c", "0")),
+                    volume=Decimal(kline.get("v", "0")),
+                    quote_volume=Decimal(kline.get("q", "0")),
+                    trades_count=int(kline.get("n", 0)),
+                    is_closed=True,
+                )
+
+                await self.save_candle_safely(session, candle)
+                await self.recalculate_indicators(session, pair.id, timeframe)
+                await self.check_trading_signals(session, pair, timeframe, candle)
+
+                await session.commit()
+
+                self.logger.info(
+                    "Kline processed and indicators updated",
                     symbol=symbol,
                     timeframe=timeframe,
-                    stream=stream_name
+                    price=float(candle.close_price),
                 )
+
+        except Exception as e:  # pragma: no cover - защита от неожиданных ошибок
+            self.logger.error("Error processing kline data", error=str(e), data=data)
+
+    async def save_candle_safely(self, session, candle) -> None:
+        """Безопасно сохранить свечу, избегая дублирования."""
+        try:
+            from sqlalchemy import select
+            from data.models.candle_model import Candle as CandleModel
+
+            existing = await session.execute(
+                select(CandleModel).where(
+                    CandleModel.pair_id == candle.pair_id,
+                    CandleModel.timeframe == candle.timeframe,
+                    CandleModel.open_time == candle.open_time,
+                )
+            )
+
+            if existing.scalar_one_or_none():
+                await session.execute(
+                    update(CandleModel)
+                    .where(
+                        CandleModel.pair_id == candle.pair_id,
+                        CandleModel.timeframe == candle.timeframe,
+                        CandleModel.open_time == candle.open_time,
+                    )
+                    .values(
+                        close_price=candle.close_price,
+                        high_price=candle.high_price,
+                        low_price=candle.low_price,
+                        volume=candle.volume,
+                        quote_volume=candle.quote_volume,
+                        trades_count=candle.trades_count,
+                        is_closed=True,
+                    )
+                )
+            else:
+                session.add(candle)
+
+            await session.flush()
+
+        except Exception as e:  # pragma: no cover - ошибки БД логируются
+            self.logger.error("Error saving candle", error=str(e))
+            await session.rollback()
+
+    async def recalculate_indicators(self, session, pair_id: int, timeframe: str) -> None:
+        """Пересчитать индикаторы для пары и таймфрейма."""
+        try:
+            from data.models.pair_model import Pair
+            from data.models.candle_model import Candle
+            from sqlalchemy import select
+
+            pair = await session.get(Pair, pair_id)
+            if not pair:
                 return
 
-            # Подготавливаем данные свечи
+            result = await session.execute(
+                select(Candle)
+                .where(
+                    Candle.pair_id == pair_id,
+                    Candle.timeframe == timeframe,
+                )
+                .order_by(Candle.open_time.desc())
+                .limit(1)
+            )
+            last_candle = result.scalar_one_or_none()
+            if not last_candle:
+                return
+
             candle_data = {
-                "open_time": int(kline_data.get("t", 0)),
-                "close_time": int(kline_data.get("T", 0)),
-                "open_price": kline_data.get("o", "0"),
-                "high_price": kline_data.get("h", "0"),
-                "low_price": kline_data.get("l", "0"),
-                "close_price": kline_data.get("c", "0"),
-                "volume": kline_data.get("v", "0")
+                "open_time": last_candle.open_time,
+                "close_time": last_candle.close_time,
+                "open_price": str(last_candle.open_price),
+                "high_price": str(last_candle.high_price),
+                "low_price": str(last_candle.low_price),
+                "close_price": str(last_candle.close_price),
+                "volume": str(last_candle.volume),
             }
 
-            # Всегда обновляем кеш
-            if is_closed:
-                await candle_cache.add_new_candle(symbol, timeframe, candle_data)
-            else:
-                await candle_cache.update_last_candle(symbol, timeframe, candle_data)
-
-            # Отправляем в систему сигналов только закрытые свечи
-            if is_closed:
-                await self._process_closed_candle(symbol, timeframe, candle_data)
-
-        except Exception as e:
-            self.logger.error(
-                "Error processing kline message",
-                stream=stream_name,
-                error=str(e)
+            await candle_cache.add_new_candle(pair.symbol, timeframe, candle_data)
+            await signal_aggregator._calculate_indicators(
+                pair.symbol, timeframe, candle_data, True
             )
 
-    async def _process_closed_candle(
-            self,
-            symbol: str,
-            timeframe: str,
-            candle_data: Dict[str, Any]
-    ) -> None:
-        """
-        Обработать закрытую свечу через систему сигналов.
+        except Exception as e:  # pragma: no cover - непредвиденная ошибка индикаторов
+            self.logger.error("Error recalculating indicators", error=str(e))
 
-        Args:
-            symbol: Символ торговой пары
-            timeframe: Таймфрейм
-            candle_data: Данные свечи
-        """
+    async def check_trading_signals(self, session, pair, timeframe: str, candle) -> None:
+        """Проверить сигналы для уведомлений."""
         try:
-            # Получаем сессию БД
-            async with get_session() as session:
-                result = await signal_aggregator.process_candle_update(
-                    session=session,
-                    symbol=symbol,
-                    timeframe=timeframe,
-                    candle_data=candle_data,
-                    is_closed=True
-                )
+            candle_data = {
+                "open_time": candle.open_time,
+                "close_time": candle.close_time,
+                "open_price": str(candle.open_price),
+                "high_price": str(candle.high_price),
+                "low_price": str(candle.low_price),
+                "close_price": str(candle.close_price),
+                "volume": str(candle.volume),
+            }
 
-                if result["total_notifications"] > 0:
-                    self.logger.info(
-                        "Signals generated from WebSocket",
-                        symbol=symbol,
-                        timeframe=timeframe,
-                        rsi_notifications=result["rsi_notifications"],
-                        ema_notifications=result["ema_notifications"],
-                        total_notifications=result["total_notifications"]
-                    )
-
-        except Exception as e:
-            self.logger.error(
-                "Error processing closed candle through signal system",
-                symbol=symbol,
+            await signal_aggregator.process_candle_update(
+                session=session,
+                symbol=pair.symbol,
                 timeframe=timeframe,
-                error=str(e)
+                candle_data=candle_data,
+                is_closed=True,
             )
+
+        except Exception as e:  # pragma: no cover - обработка ошибок сигналов
+            self.logger.error("Error checking trading signals", error=str(e))
 
     async def _process_ticker_message(self, stream_name: str, data: Dict[str, Any]) -> None:
-        """
-        Обработать ticker сообщение (пока заглушка).
-
-        Args:
-            stream_name: Название потока
-            data: Данные ticker
-        """
+        """Обработать ticker сообщение (заглушка)."""
         # TODO: Реализовать обработку ticker данных если нужно
-        pass
+        _ = (stream_name, data)
 
     def get_processing_stats(self) -> Dict[str, Any]:
-        """
-        Получить статистику обработки.
+        """Получить статистику обработки."""
+        success_rate = (
+            (self.processed_messages - self.processing_errors)
+            / max(1, self.processed_messages)
+        ) * 100 if self.processed_messages > 0 else 0
 
-        Returns:
-            Dict: Статистика обработки
-        """
         return {
             "processed_messages": self.processed_messages,
             "processing_errors": self.processing_errors,
-            "success_rate": (
-                                    (self.processed_messages - self.processing_errors) /
-                                    max(1, self.processed_messages)
-                            ) * 100 if self.processed_messages > 0 else 0
+            "success_rate": success_rate,
         }
 
 
 # Глобальный экземпляр обработчика
 binance_data_processor = BinanceDataProcessor()
+


### PR DESCRIPTION
## Summary
- handle closed kline data by storing candles and recalculating indicators
- avoid candle duplication when saving to DB
- hook kline processing into signal generation

## Testing
- `pytest` *(fails: fixture 'self' not found in scripts/test_websocket.py)*

------
https://chatgpt.com/codex/tasks/task_e_688ab997db5c832bab5ac45873a13ae2