### PR TITLE
feat: subscribe to user pairs on startup

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -150,6 +150,8 @@ async def init_services() -> None:
     logger.info("Starting WebSocket stream manager...")
     stream_manager = StreamManager()
     await stream_manager.start()
+    await stream_manager.subscribe_to_user_pairs()
+    logger.info("WebSocket subscribed to all user pairs")
     logger.info("WebSocket stream manager started")
 
     logger.info("All services initialized successfully")


### PR DESCRIPTION
## Summary
- automatically subscribe WebSocket stream manager to all user pairs on startup

## Testing
- `pytest -q` *(fails: fixture 'self' not found in scripts/test_websocket.py)*

------
https://chatgpt.com/codex/tasks/task_e_688ab9b4fe38832bbd222e2ca458839e